### PR TITLE
Don't require symfony/flex globally

### DIFF
--- a/.github/workflows/test-upcoming-symfony.yaml
+++ b/.github/workflows/test-upcoming-symfony.yaml
@@ -39,7 +39,7 @@ jobs:
               env:
                   SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
               run: |
-                  composer global require --no-progress --no-scripts --no-plugins symfony/flex
+                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader || exit 0
                   vendor/bin/simple-phpunit install || exit 0
 

--- a/.github/workflows/test-upcoming-symfony.yaml
+++ b/.github/workflows/test-upcoming-symfony.yaml
@@ -36,10 +36,9 @@ jobs:
                   ini-values: date.timezone=UTC
 
             - name: 'Install project dependencies'
-              env:
-                  SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
               run: |
                   composer require --no-progress --no-scripts --no-plugins symfony/flex
+                  composer config extra.symfony.require "${{ matrix.symfony-version }}"
                   composer update --no-interaction --prefer-dist --optimize-autoloader || exit 0
                   vendor/bin/simple-phpunit install || exit 0
 

--- a/.github/workflows/test-upcoming-symfony.yaml
+++ b/.github/workflows/test-upcoming-symfony.yaml
@@ -39,7 +39,6 @@ jobs:
               env:
                   SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
               run: |
-                  composer config --global --no-plugins allow-plugins.symfony/flex true
                   composer global require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader || exit 0
                   vendor/bin/simple-phpunit install || exit 0

--- a/.github/workflows/tests-linux.yaml
+++ b/.github/workflows/tests-linux.yaml
@@ -36,7 +36,7 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
-                  composer global require --no-progress --no-scripts --no-plugins symfony/flex
+                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
                   vendor/bin/simple-phpunit install
 

--- a/.github/workflows/tests-linux.yaml
+++ b/.github/workflows/tests-linux.yaml
@@ -36,7 +36,6 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
-                  composer config --global --no-plugins allow-plugins.symfony/flex true
                   composer global require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
                   vendor/bin/simple-phpunit install

--- a/.github/workflows/tests-lowest-dependencies.yaml
+++ b/.github/workflows/tests-lowest-dependencies.yaml
@@ -32,7 +32,7 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
-                  composer global require --no-progress --no-scripts --no-plugins symfony/flex
+                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable --prefer-lowest
                   vendor/bin/simple-phpunit install
 

--- a/.github/workflows/tests-lowest-dependencies.yaml
+++ b/.github/workflows/tests-lowest-dependencies.yaml
@@ -32,7 +32,6 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
-                  composer config --global --no-plugins allow-plugins.symfony/flex true
                   composer global require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable --prefer-lowest
                   vendor/bin/simple-phpunit install

--- a/.github/workflows/tests-macos.yaml
+++ b/.github/workflows/tests-macos.yaml
@@ -32,7 +32,6 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
-                  composer config --global --no-plugins allow-plugins.symfony/flex true
                   composer global require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
                   vendor/bin/simple-phpunit install

--- a/.github/workflows/tests-macos.yaml
+++ b/.github/workflows/tests-macos.yaml
@@ -32,7 +32,7 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
-                  composer global require --no-progress --no-scripts --no-plugins symfony/flex
+                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
                   vendor/bin/simple-phpunit install
 

--- a/.github/workflows/tests-maintained-symfony.yaml
+++ b/.github/workflows/tests-maintained-symfony.yaml
@@ -39,7 +39,7 @@ jobs:
               env:
                   SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
               run: |
-                  composer global require --no-progress --no-scripts --no-plugins symfony/flex
+                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader
                   vendor/bin/simple-phpunit install
 

--- a/.github/workflows/tests-maintained-symfony.yaml
+++ b/.github/workflows/tests-maintained-symfony.yaml
@@ -39,7 +39,6 @@ jobs:
               env:
                   SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
               run: |
-                  composer config --global --no-plugins allow-plugins.symfony/flex true
                   composer global require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader
                   vendor/bin/simple-phpunit install

--- a/.github/workflows/tests-maintained-symfony.yaml
+++ b/.github/workflows/tests-maintained-symfony.yaml
@@ -36,10 +36,9 @@ jobs:
                   ini-values: date.timezone=UTC
 
             - name: 'Install project dependencies'
-              env:
-                  SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
               run: |
                   composer require --no-progress --no-scripts --no-plugins symfony/flex
+                  composer config extra.symfony.require "${{ matrix.symfony-version }}"
                   composer update --no-interaction --prefer-dist --optimize-autoloader
                   vendor/bin/simple-phpunit install
 

--- a/.github/workflows/tests-upcoming-php.yaml
+++ b/.github/workflows/tests-upcoming-php.yaml
@@ -34,7 +34,6 @@ jobs:
               env:
                   SYMFONY_REQUIRE: 5.4
               run: |
-                  composer config --global --no-plugins allow-plugins.symfony/flex true
                   composer global require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable --ignore-platform-req=php
                   vendor/bin/simple-phpunit install

--- a/.github/workflows/tests-upcoming-php.yaml
+++ b/.github/workflows/tests-upcoming-php.yaml
@@ -31,10 +31,9 @@ jobs:
                   ini-values: date.timezone=UTC
 
             - name: 'Install project dependencies'
-              env:
-                  SYMFONY_REQUIRE: 5.4
               run: |
                   composer require --no-progress --no-scripts --no-plugins symfony/flex
+                  composer config extra.symfony.require "5.4"
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable --ignore-platform-req=php
                   vendor/bin/simple-phpunit install
 

--- a/.github/workflows/tests-upcoming-php.yaml
+++ b/.github/workflows/tests-upcoming-php.yaml
@@ -34,7 +34,7 @@ jobs:
               env:
                   SYMFONY_REQUIRE: 5.4
               run: |
-                  composer global require --no-progress --no-scripts --no-plugins symfony/flex
+                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable --ignore-platform-req=php
                   vendor/bin/simple-phpunit install
 

--- a/.github/workflows/tests-windows.yaml
+++ b/.github/workflows/tests-windows.yaml
@@ -32,7 +32,6 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
-                  composer config --global --no-plugins allow-plugins.symfony/flex true
                   composer global require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
                   vendor/bin/simple-phpunit install

--- a/.github/workflows/tests-windows.yaml
+++ b/.github/workflows/tests-windows.yaml
@@ -32,7 +32,7 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
-                  composer global require --no-progress --no-scripts --no-plugins symfony/flex
+                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
                   vendor/bin/simple-phpunit install
 

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,10 @@
         "symfony/phpunit-bridge": "^5.4|^6.0"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
TODO: [submit the changes](https://github.com/EasyCorp/EasyAdminBundle/compare/4.x...alexislefebvre:EasyAdminBundle:don-t-require-symfony/flex-globally) to upstream when submissions will be reopened.